### PR TITLE
614: Adding deleted field to apiClient

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/apiClient.json
+++ b/config/defaults/secure-open-banking/managed-objects/apiClient.json
@@ -127,6 +127,16 @@
             "isVirtual": false,
             "deleteQueryConfig": false
           },
+          "deleted": {
+            "title": "Deleted",
+            "type": "boolean",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": true,
+            "description": "Has the ApiClient record been deleted",
+            "isVirtual": false,
+            "default": false
+          },
           "domesticPaymentIntents": {
             "description": "",
             "title": "Domesticpaymentintents",
@@ -219,6 +229,7 @@
           "id",
           "name",
           "description",
+          "deleted",
           "logoUri",
           "jwksUri",
           "ssa",
@@ -231,7 +242,8 @@
           "id",
           "name",
           "oauth2ClientId",
-          "ssa"
+          "ssa",
+          "deleted"
         ],
         "mat-icon": null
       },


### PR DESCRIPTION
Adding deleted field to apiClient, this field is mandatory and is defaulted to false.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/614