### PR TITLE
865: Changing apiClient.roles property type from string to array of strings

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/apiClient.json
+++ b/config/defaults/secure-open-banking/managed-objects/apiClient.json
@@ -68,7 +68,10 @@
           },
           "roles": {
             "title": "Roles",
-            "type": "string",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
             "viewable": true,
             "searchable": false,
             "userEditable": true


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/865