### PR TITLE
939 standardise helm charts

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/readme.md
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/readme.md
@@ -177,7 +177,7 @@ These are the environment variables declared in the `deployment.yaml`;
 | ENVIRONMENT.TYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | deployment-config |
 | IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | deployment-config |
 | HOSTS.BASE_FQDN | forgerock.financial | Base DNS to be used | deployment-config |
-| HOSTS.IG_FQDN | sapig.forgerock.financial | IG DNS to be used | deployment-config
+| HOSTS.IG_FQDN | sapig.forgerock.financial | IG DNS to be used | deployment-config |
 | HOSTS.MTLS_FQDN | mtls.sapig.forgerock.financial | mtls DNS to be used | deployment-config |
 | HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | deployment-config |
 | IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE | | | deployment-config | X |

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/readme.md
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/readme.md
@@ -170,7 +170,7 @@ spec:
 ```
 ### Environment Variables
 
-These are the environment variables declared in the `deployment.yaml`;
+These are the environment variables declared in the `cronjob.yaml`;
 | Key | Default | Description | Source | Optional |
 |-----|---------|-------------|--------|----------|
 | ENVIRONMENT.STRICT | true | If true, any errors will cause the job to exit | cronjob.environment.strict |

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/readme.md
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/readme.md
@@ -1,0 +1,226 @@
+# Secure API Gateway - FIDC-Initializer
+
+
+See [README](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-fidc-initializer/blob/master/README.md) for information on FIDC-Initializer
+
+## Prerequisites
+
+- Kubernetes v1.23 +
+- Helm 3.0.0 +
+
+To add the forgerock helm artifactory repository to your local machine to consume helm charts use the following;
+
+```console
+  helm repo add forgerock-helm https://maven.forgerock.org/artifactory/forgerock-helm-virtual/ --username [backstage_username]  --password [backstage_password]
+  helm repo update
+```
+
+NOTE: You must have a valid [subscription](https://backstage.forgerock.com/knowledge/kb/article/a57648047#XAYQfS) to aquire the `backstage_username` and `backstage_password` values.
+
+## Helm Charts
+### Deployment
+FIDC-Configurator is primarily used for development environments and not intended to run in production.
+
+As part of a development deployment of the secure-api-gateway, you must build the java artifacts and built the docker image via the [Makefile](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-fidc-initializer/blob/master/Makefile). 
+
+TODO: Add in commands to deploy the FIDC to a development environment without ArgoCD
+
+### Example Manifest
+This is an example manifest using the `values.yaml` file provided, there is no overlay values in this generated manifest hence why there is no repo URL in `spec.jobTemplate.spec.containers.0.image`.
+
+```yaml
+---
+# Source: securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fidc-configurator
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  startingDeadlineSeconds: 180
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: fidc-configurator
+              image: ":1.0.0"
+              imagePullPolicy: Always
+              env:
+                - name: ENVIRONMENT.STRICT
+                  value: "true"
+                - name: ENVIRONMENT.TYPE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: ENVIRONMENT_TYPE
+                - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: IDENTITY_PLATFORM_FQDN
+                - name: HOSTS.BASE_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: BASE_FQDN
+                - name: HOSTS.IG_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: IG_FQDN
+                - name: HOSTS.MTLS_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: MTLS_FQDN
+                - name: HOSTS.IDENTITY_PLATFORM_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: IDENTITY_PLATFORM_FQDN
+                - name: IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE
+                      optional: true
+                - name: IDENTITY.GOOGLE_SECRET_STORE_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: IDENTITY_GOOGLE_SECRET_STORE_NAME
+                      optional: true
+                - name: IDENTITY.GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: IDENTITY_GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME
+                      optional: true
+                - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: initializer-secret
+                      key: cdm-admin-password
+                - name: USERS.FR_PLATFORM_ADMIN_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: initializer-secret
+                      key: cdm-admin-user
+                - name: IDENTITY.REMOTE_CONSENT_SIGNING_PUBLIC_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rcs-signing
+                      key: rcs-signing.pem
+                - name: IDENTITY.REMOTE_CONSENT_SIGNING_KEY_ID
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID
+                - name: IDENTITY.REMOTE_CONSENT_ID
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: RCS_CONSENT_RESPONSE_JWT_ISSUER
+                - name: IG.IG_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_CLIENT_ID
+                - name: IG.IG_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_CLIENT_SECRET
+                - name: IG.IG_IDM_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_IDM_USER
+                - name: IG.IG_IDM_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_IDM_PASSWORD
+                - name: IG.IG_AGENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_AGENT_ID
+                - name: IG.IG_AGENT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_AGENT_PASSWORD
+              command: [ "/bin/sh", "-c" ]
+              args:
+                - |
+                  echo "IDENTITY_PLATFORM_FQDN $IDENTITY_PLATFORM_FQDN"
+                  until $(curl -X GET --output /dev/null --silent --head --fail -H "X-OpenIDM-Username: anonymous" \
+                  -H "X-OpenIDM-Password: anonymous" -H "X-OpenIDM-NoSession: true" \
+                  https://$IDENTITY_PLATFORM_FQDN/openidm/info/ping)
+                  do
+                  echo "IDM not ready"
+                  sleep 10
+                  done
+                  ./initialize
+          restartPolicy: OnFailure
+```
+### Environment Variables
+
+These are the environment variables declared in the `deployment.yaml`;
+| Key | Default | Description | Source | Optional |
+|-----|---------|-------------|--------|----------|
+| ENVIRONMENT.STRICT | true | If true, any errors will cause the job to exit | cronjob.environment.strict |
+| ENVIRONMENT.TYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | deployment-config |
+| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | deployment-config |
+| HOSTS.BASE_FQDN | forgerock.financial | Base DNS to be used | deployment-config |
+| HOSTS.IG_FQDN | sapig.forgerock.financial | IG DNS to be used | deployment-config
+| HOSTS.MTLS_FQDN | mtls.sapig.forgerock.financial | mtls DNS to be used | deployment-config |
+| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | deployment-config |
+| IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE | | | deployment-config | X |
+| IDENTITY.GOOGLE_SECRET_STORE_NAME | | | deployment-config | X |
+| IDENTITY.GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME | | | deployment-config | X |
+| USERS.FR_PLATFORM_ADMIN_PASSWORD | | Password for cloud instance. NOTE - This password can be used for `initializer-secret` or `am-env-secrets` depending on `ENVIRONMENT.TYPE` set | If `ENVIRONMENT.TYPE=FIDC` initializer-secret/cdm-admin-password else am-env-secrets/AM_PASSWORDS_AMADMIN_CLEAR |
+| USERS.FR_PLATFORM_ADMIN_USERNAME | | Username for cloud instance, only populated if `ENVIRONMENT.TYPE=FIDC` | initializer-secret/cdm-admin-user |
+| IDENTITY.REMOTE_CONSENT_SIGNING_PUBLIC_KEY | PEM File | The pem file to be used for RCS signing | rcs-signing secret | 
+| IDENTITY.REMOTE_CONSENT_SIGNING_KEY_ID | rcs-jwt-signer | | deployment-config/RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID 
+IDENTITY.REMOTE_CONSENT_ID | secure-open-banking-rcs | | deployment-config/RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID | 
+| IG.IG_CLIENT_ID | | | openig-secrets-env |
+| IG.IG_CLIENT_SECRET | | | openig-secrets-env |
+| IG.IG_IDM_USER | | | openig-secrets-env |
+| IG.IG_IDM_PASSWORD | | | openig-secrets-env |
+| IG.IG_AGENT_ID | | | openig-secrets-env |
+| IG.IG_AGENT_PASSWORD | | | openig-secrets-env |
+
+### Values
+These are the values that are consumed in the `deployment.yaml` and `service.yaml`;
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+| cronjob.concurrencyPolicy | string |   # Policy of allowing concurrent pods to run | Forbid |
+| cronjob.environment.frPlatformType | string | Type of Cloud Instance being ran, depends on what environment you are running | FIDC |
+| cronjob.environment.strict | bool | If true, any errors will cause the job to exit | true |
+| cronjob.image.repo | string | Repo to pull images from - Value should exist in values.yaml overlay in deployment repo | {} |
+| cronjob.image.tag | string | Tag to deploy - Value should exist in values.yaml overlay in deployment repo | {} |
+| cronjob.image.imagePullPolicy | string | Policy for pulling images | Always |
+| cronjob.schedule | cron expression | What schedule the cronjob should run on | * * * * * (Every minute) |
+| cronjob.seccessfulJobHistoryLimit | integer | How many successful jobs should be kept for histroy | 1 |
+| cronjob.startingDeadlineSeconds | integer | Time in seconds to deplay starting the cronjob once deployed | 180 |
+| cronjob.restartPolicy | string | When to restart the pod | OnFailure |
+
+NOTE: There is no `deployment.image.repo` or `deployment.image.tag` specified in the `Values.yaml` - This needs to be done in a seperate 'deployments' repo using an additional `values.yaml` overlay. You may overwrite any of the other values in this additonal file if required.
+
+Example of the RCS section of the additonal `values.yaml` file;
+```yaml
+fidc-configurator:
+  deployment:  
+    image:
+      repo: [REPO_URL]
+      # By default the AppVersion will be used so that users don't have to change this value, however you can override this by uncommenting the line and providing a valid verison.
+      # tag: 1.0.1
+```
+## Support
+
+For any issues or questions, please raise an issue within the [SecureApiGateway](https://github.com/SecureApiGateway/SecureApiGateway/issues) repository.

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -6,7 +6,7 @@ spec:
   schedule: "{{ .Values.cronjob.schedule }}"
   concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy }}
   successfulJobsHistoryLimit: {{ .Values.cronjob.seccessfulJobHistoryLimit}}
-  startingDeadlineSeconds: {{. Values.cronjob.startingDeadlineSeconds}}
+  startingDeadlineSeconds: {{ .Values.cronjob.startingDeadlineSeconds}}
   jobTemplate:
     spec:
       template:

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -3,25 +3,21 @@ kind: CronJob
 metadata:
   name: {{ .Chart.Name }}
 spec:
-  schedule: "{{ .Values.cron }}"
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 1
-  startingDeadlineSeconds: 180
+  schedule: "{{ .Values.cronjob.schedule }}"
+  concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.seccessfulJobHistoryLimit}}
+  startingDeadlineSeconds: {{. Values.cronjob.startingDeadlineSeconds}}
   jobTemplate:
     spec:
       template:
         spec:
           containers:
             - name: {{ .Chart.Name }}
-              {{- if .Values.deployment.imageOverride.enabled }}
-              image: "{{ .Values.deployment.imageOverride.repo }}/{{ .Values.deployment.imageOverride.iam_initializer_image_name}}:{{ .Values.deployment.imageOverride.iam_initializer_image_tag }}"
-              {{- else }}
-              image: "eu.gcr.io/sbat-gcr-release/securebanking/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
-              {{- end }}
-              imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+              image: "{{ .Values.cronjob.image.repo }}:{{ default .Chart.AppVersion .Values.cronjob.image.tag }}"
+              imagePullPolicy: {{ .Values.cronjob.image.imagePullPolicy }}
               env:
                 - name: ENVIRONMENT.STRICT
-                  value: {{ .Values.environment.strict | quote }}
+                  value: {{ .Values.cronjob.environment.strict | quote }}
                 - name: ENVIRONMENT.TYPE
                   valueFrom:
                     configMapKeyRef:
@@ -70,7 +66,7 @@ spec:
                       name: deployment-config
                       key: IDENTITY_GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME
                       optional: true
-                {{- if eq .Values.environment.fr_platform.type "FIDC" }}
+                {{- if eq .Values.cronjob.environment.frPlatformType "FIDC" }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -145,4 +141,4 @@ spec:
                   sleep 10
                   done
                   ./initialize
-          restartPolicy: OnFailure
+          restartPolicy: {{ .Values.cronjob.restartPolicy }}

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -11,7 +11,10 @@ cronjob:
     # STRICT mode will simply warn of client/server errors.
     strict: true
   image:
-    # repo: 
+    # Repo And Tag are not provided here as the value for the repo will be unique for each user/customer as they will be building their own docker images and push to their own Container Registries 
+    # The tag will use the .AppVersion as the default, meaning that customers who want to install V1 will get V1.0.0 of the software - you may supply a hard coded version if required  
+    # The values for each of these should be supplied in the .Values folder of an individual deployment within the specification repository - See https://github.com/SecureApiGateway/SecureApiGateway/wiki/Deployment#repositories
+    # repo:
     # tag:
     imagePullPolicy: Always
   schedule: "* * * * *"

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -1,5 +1,6 @@
 ---
 cronjob:
+  # Policy of allowing concurrent pods to run
   concurrencyPolicy: Forbid
   environment:
     # CDK value: (Cloud Developer's Kit) development identity platform
@@ -16,8 +17,13 @@ cronjob:
     # The values for each of these should be supplied in the .Values folder of an individual deployment within the specification repository - See https://github.com/SecureApiGateway/SecureApiGateway/wiki/Deployment#repositories
     # repo:
     # tag:
+    # We want to pull the image down each time we do a deployment, required if using 'latest' tag
     imagePullPolicy: Always
+  # When the cronjob should run - default is every minute
   schedule: "* * * * *"
+  # How many successful jobs should be kept for histroy 
   seccessfulJobHistoryLimit: 1
+  # Time in seconds to deplay starting the cronjob once deployed
   startingDeadlineSeconds: 180
+  # When to restart the pod
   restartPolicy: OnFailure

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -1,46 +1,20 @@
-cron: "* * * * *"
-  
-deployment:  
-  imageOverride:
-    enabled: true
-    repo: eu.gcr.io/sbat-gcr-develop/securebanking
-    iam_initializer_image_name: secureopenbanking-uk-iam-initializer
-    iam_initializer_image_tag: latest
-  imagePullPolicy: Always
-
-# ** Value Name:** iam_initializer_image_location
-#
-# ** Value Description** 
-# Location of the image in your docker repository. Override this in your own values file.
-# The template expects a tpl value, which enables the image location to be built up from
-# values containing repo location, image name etc. e.g.
-# 
-#  # Values from file
-#  helm_repository: eu.gcr.io/sbat-gcr-develop/securebanking
-#  iam_initializer_image_name: secureopenbanking-uk-iam-initializer
-#  iam_initializer_image_tag: latest
-#  iam_initializer_image_location: "{{ .Values.helm_repository }}/{{ .Values.iam_initializer_image_name }}:{{ .Values.iam_initializer_image_tag}}"
-
-
-# environment.type: It can be:
-# CDK value: (Cloud Developer's Kit) development identity platform
-# CDM value: CDM (Cloud Deployment Model) identity cloud platform
-# FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
-environment:
-  # Configuration relating to the FR Platform
-  fr_platform:
-    type: FIDC
-    fqdn: iam.dev.forgerock.financial
-  # Configuration relation to the SBAT deployment
-  sbat: 
-    # The GCP project in which the SBAT is deployed
-    projectId: sbat-dev
-    fqdn: dev.forgerock.financial
-  
-  # RaiseForStatus will exit if go resty returns an error in STRICT mode,
-  # be it client error, server error or other. Turning off (false)
-  # STRICT mode will simply warn of client/server errors.
-  strict: true
-  cdmadminpassword: change
-
-
+---
+cronjob:
+  concurrencyPolicy: Forbid
+  environment:
+    # CDK value: (Cloud Developer's Kit) development identity platform
+    # CDM value: CDM (Cloud Deployment Model) identity cloud platform
+    # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
+    frPlatformType: FIDC
+    # RaiseForStatus will exit if go resty returns an error in STRICT mode,
+    # be it client error, server error or other. Turning off (false)
+    # STRICT mode will simply warn of client/server errors.
+    strict: true
+  image:
+    # repo: 
+    # tag:
+    imagePullPolicy: Always
+  schedule: "* * * * *"
+  seccessfulJobHistoryLimit: 1
+  startingDeadlineSeconds: 180
+  restartPolicy: OnFailure


### PR DESCRIPTION
Remove image override option, and use a default of appVersion if an deployment.image.tag value is not provided (SBAT will now provide this so that the latest image is deployed, and we'll want to not provide the value in relenvs so that the appVersion is used)

Remove unwanted values from values.yaml
Order alphabetically in values.yaml
Standardise values.yaml

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/939