### PR TITLE
940: Create a PR that will disable the fidc-configurator

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -1,4 +1,4 @@
-cron: "* * * * *"
+cron: "* * * * MON"
   
 deployment:  
   imageOverride:


### PR DESCRIPTION
This will be applied in nightly so that we have time to delete the policy script and the PISP and AISP policies that use it, and then recreate them using teh cs_config_manager

NOTE: THIS PR SHOULD NOT BE MERGED!

Issue: https://github.com/secureapigateway/secureapigateway/issues/940