### PR TITLE
901 Disable initializer for nightly env

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if eq .Values.cronjob.enabled "true" }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -143,3 +144,4 @@ spec:
                   done
                   ./initialize
           restartPolicy: {{ .Values.cronjob.restartPolicy }}
+{{ end }}

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -2,6 +2,7 @@
 cronjob:
   # Policy of allowing concurrent pods to run
   concurrencyPolicy: Forbid
+  # We might not want to run the fidc configurator in all environments (for example Nightly) - setting to false will skip creating the fidc configurator in the cluster
   enabled: true
   environment:
     # CDK value: (Cloud Developer's Kit) development identity platform

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -2,6 +2,7 @@
 cronjob:
   # Policy of allowing concurrent pods to run
   concurrencyPolicy: Forbid
+  enabled: true
   environment:
     # CDK value: (Cloud Developer's Kit) development identity platform
     # CDM value: CDM (Cloud Deployment Model) identity cloud platform


### PR DESCRIPTION
Only install the cronjob if the value enabled is true in values.yaml, for nightly we will override this value in the pipeline as we no longer want it running in nightly

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/901