### PR TITLE
1078: Allow GOOGLE_SECRET_STORE_PROJECT value to be overridden via helm

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -61,6 +61,12 @@ spec:
                       name: deployment-config
                       key: IDENTITY_GOOGLE_SECRET_STORE_NAME
                       optional: true
+                - name: IDENTITY.GOOGLE_SECRET_STORE_PROJECT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: deployment-config
+                      key: IDENTITY_GOOGLE_SECRET_STORE_PROJECT
+                      optional: true
                 - name: IDENTITY.GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/1078