### PR TITLE
987: Artifact Registry Migration

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,7 +22,8 @@ jobs:
         run: |
           make test-ci
 
-      - uses: google-github-actions/auth@v2
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
@@ -30,7 +31,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
+      - name: Auth Docker
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: docker build

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,19 +22,19 @@ jobs:
         run: |
           make test-ci
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: docker build
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,8 +11,8 @@ env:
   PR_NUMBER: pr-${{ github.event.number }}
 
 jobs:
-  build:
-    name: Build
+  check:
+    name: Check Changes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,8 +21,16 @@ jobs:
       - name: Run Tests
         run: |
           make test-ci
+  build:
+    name: Build
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - uses: google-github-actions/auth@v2
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
@@ -30,12 +38,19 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
+      - name: Auth Docker
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: docker build
         run: |
           make docker tag=${{ env.PR_NUMBER }}
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
 
       - name: Create lowercase Github Username
         id: toLowerCase

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,16 +22,16 @@ jobs:
         run: |
           make test-ci
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: docker build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
         run: |
           make test-ci
 
-      - uses: google-github-actions/auth@v2
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
@@ -26,7 +27,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
+      - name: Auth Docker
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: docker build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,17 +18,17 @@ jobs:
         run: |
           make test-ci
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: docker build
         run: |
-          make docker release-repo=${{ secrets.RELEASE_REPO }}
+          make docker release-repo=${{ vars.GAR_RELEASE_REPO }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 service := secureopenbanking-uk-iam-initializer
-gcr-repo := sbat-gcr-develop
+gcr-repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
 binary-name := initialize
 
 
@@ -30,9 +30,9 @@ ifndef tag
 	$(eval tag=latest)
 endif
 	env GOOS=linux GOARCH=amd64 go build -o initialize
-	docker buildx build --platform linux/amd64  -t eu.gcr.io/${gcr-repo}/securebanking/${service}:${tag} .
-	docker push eu.gcr.io/${gcr-repo}/securebanking/${service}:${tag}
+	docker buildx build --platform linux/amd64  -t ${gcr-repo}/securebanking/${service}:${tag} .
+	docker push ${gcr-repo}/securebanking/${service}:${tag}
 ifdef release-repo
-	docker tag eu.gcr.io/${gcr-repo}/securebanking/${service}:${tag} eu.gcr.io/${release-repo}/securebanking/${service}:${tag}
-	docker push eu.gcr.io/${release-repo}/securebanking/${service}:${tag}
+	docker tag ${gcr-repo}/securebanking/${service}:${tag} ${release-repo}/securebanking/${service}:${tag}
+	docker push ${release-repo}/securebanking/${service}:${tag}
 endif

--- a/quick-deployment4tests.md
+++ b/quick-deployment4tests.md
@@ -1,14 +1,14 @@
 ## How tests the changes
 1. `make docker`
 1. ```shell
-   docker tag eu.gcr.io/sbat-gcr-develop/securebanking/secureopenbanking-uk-fidc-initializer:latest eu.gcr.io/sbat-gcr-release/securebanking/secureopenbanking-uk-fidc-initializer:latest
+   docker tag europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/secureopenbanking-uk-fidc-initializer:latest europe-west4-docker.pkg.dev/sbat-gcr-release/sapig-docker-artifact/securebanking/secureopenbanking-uk-fidc-initializer:latest
    ```
 1. ```shell
    docker push !$[+TAB]
    ```
    Or
    ```shell
-   docker push eu.gcr.io/sbat-gcr-release/securebanking/secureopenbanking-uk-fidc-initializer:latest
+   docker push europe-west4-docker.pkg.dev/sbat-gcr-release/sapig-docker-artifact/securebanking/secureopenbanking-uk-fidc-initializer:latest
    ```
 1. Change kubernetes context to `sbat-master-dev`
 1. Set the namespace to `ig`


### PR DESCRIPTION
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated

Issue:
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202