### PR TITLE
1275: Configuring the OAuth2.0 Provider supportedAuthorizationResponseSigningAlgorithms

### DIFF
--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -155,6 +155,9 @@
     "supportedUserInfoSigningAlgorithms": [
       "PS256"
     ],
+    "supportedAuthorizationResponseSigningAlgorithms": [
+      "PS256"
+    ],
     "supportedTokenIntrospectionResponseEncryptionEnc": [
       "A256GCM",
       "A192GCM",


### PR DESCRIPTION
Adding supportedAuthorizationResponseSigningAlgorithms configuration for the OAuth2.0 Provider to control the signing algorithms supported for signing JARM responses. Setting this to PS256 as this is FAPI compliant.

Without this configuration, then the default signing alg of RS256 is used which is not FAPI compliant.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1275