### PR TITLE
1275: Configuring the OAuth2.0 Provider supportedAuthorizationResponseSigningAlgorithms

### DIFF
--- a/pkg/types/oauth2models.go
+++ b/pkg/types/oauth2models.go
@@ -94,6 +94,7 @@ type (
 		SupportedTokenIntrospectionResponseEncryptionEnc        []string      `json:"supportedTokenIntrospectionResponseEncryptionEnc"`
 		SupportedTokenIntrospectionResponseEncryptionAlgorithms []string      `json:"supportedTokenIntrospectionResponseEncryptionAlgorithms"`
 		AuthorisedIdmDelegationClients                          []interface{} `json:"authorisedIdmDelegationClients"`
+		SupportedAuthorizationResponseSigningAlgorithms         []string      `json:"supportedAuthorizationResponseSigningAlgorithms"`
 	}
 
 	ClientDynamicRegistrationConfig struct {


### PR DESCRIPTION
Fixes for https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-fidc-initializer/pull/202

Adding `supportedAuthorizationResponseSigningAlgorithms` to the oauth2models

https://github.com/SecureApiGateway/SecureApiGateway/issues/1275