### PR TITLE
1345: Remove use of jwksproxy from Open Banking Test Directory Software Publisher

### DIFF
--- a/pkg/securebanking/oauth2.go
+++ b/pkg/securebanking/oauth2.go
@@ -201,7 +201,7 @@ func CreateSoftwarePublisherAgentOBTestDirectory() {
 		},
 		JwksURI: types.InheritedValueString{
 			Inherited: false,
-			Value:     "https://" + common.Config.Hosts.IgFQDN + "/jwkms/jwksproxy/keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
+			Value:     "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
 		},
 	}
 	path := "/am/json/realms/root/realms/" + common.Config.Identity.AmRealm + "/realm-config/agents/SoftwarePublisher/" + common.Config.Identity.ObTestDirectorySoftwarePublisherAgent


### PR DESCRIPTION
Open Banking Test Directory Software Publisher is now configured to access the Open Banking Test Directory jwks_uri directly as we expect the AM truststore to be configured correctly.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1345