### PR TITLE
1338: Supporting OB Test Directory in a core deployment

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,21 +91,21 @@ func main() {
 
 	fmt.Println("Attempt PSD2 authentication trees initialization...")
 	securebanking.CreateSecureBankingPSD2AuthenticationTrees()
-	
+
 	if common.Config.Environment.SapigType == "ob" {
 		fmt.Println("Attempt to create secure banking remote consent...")
 		securebanking.CreateSecureBankingRemoteConsentService()
-
-		fmt.Println("Attempt to create OB Test Directory software publisher agent...")
-		securebanking.CreateSoftwarePublisherAgentOBTestDirectory()
 	}
-		
-	fmt.Println("Attempt to create OBRI software publisher agent...")
-	securebanking.CreateSoftwarePublisherAgentOBRI()
+
+	// We want to support the OB Test Directory in both core and OB deployments.
+	// For core, this means we can use OB certs when registering TPPs which is much simpler to configure than using
+	// certs issued by the Test Trusted Directory.
+	fmt.Println("Attempt to create OB Test Directory software publisher agent...")
+	securebanking.CreateSoftwarePublisherAgentOBTestDirectory()
 
 	fmt.Println("Attempt to create Test software publisher agent...")
 	securebanking.CreateSoftwarePublisherAgentTestPublisher()
-	
+
 	fmt.Println("Attempt to create OIDC claims script..")
 	id := securebanking.CreateOIDCClaimsScript(session.Cookie)
 	if common.Config.Environment.SapigType == "ob" {
@@ -129,7 +129,7 @@ func main() {
 
 	fmt.Println("Attempt to Add IAM Managed Objects...")
 	securebanking.AddIamManagedObjects()
-	
+
 	securebanking.CreateApiJwksEndpoint()
 }
 

--- a/pkg/securebanking/oauth2.go
+++ b/pkg/securebanking/oauth2.go
@@ -122,52 +122,6 @@ func remoteConsentExists(name string) bool {
 	})
 }
 
-func CreateSoftwarePublisherAgentOBRI() {
-	if softwarePublisherAgentExists(common.Config.Identity.ObriSoftwarePublisherAgent) {
-		zap.L().Info("Skipping creation of Software publisher agent")
-		return
-	}
-
-	zap.L().Info("Creating software publisher agent")
-	pa := types.PublisherAgent{
-		PublicKeyLocation: types.InheritedValueString{
-			Inherited: false,
-			Value:     "jwks_uri",
-		},
-		JwksCacheTimeout: types.InheritedValueInt{
-			Inherited: false,
-			Value:     3600000,
-		},
-		SoftwareStatementSigningAlgorithm: types.InheritedValueString{
-			Inherited: false,
-			Value:     "PS256",
-		},
-		JwkSet: types.JwkSet{
-			Inherited: false,
-		},
-		Issuer: types.InheritedValueString{
-			Inherited: false,
-			Value:     "ForgeRock",
-		},
-		JwkStoreCacheMissCacheTime: types.InheritedValueInt{
-			Inherited: false,
-			Value:     60000,
-		},
-		JwksURI: types.InheritedValueString{
-			Inherited: false,
-			Value:     "https://service.directory.ob.forgerock.financial/api/directory/keys/jwk_uri",
-		},
-	}
-	path := "/am/json/realms/root/realms/" + common.Config.Identity.AmRealm + "/realm-config/agents/SoftwarePublisher/" + common.Config.Identity.ObriSoftwarePublisherAgent
-	s := httprest.Client.Put(path, pa, map[string]string{
-		"Accept":             "*/*",
-		"Connection":         "keep-alive",
-		"Accept-API-Version": "protocol=2.0,resource=1.0",
-	})
-
-	zap.S().Infow("Software Publisher Agent", "statusCode", s)
-}
-
 func CreateSoftwarePublisherAgentOBTestDirectory() {
 	if softwarePublisherAgentExists(common.Config.Identity.ObTestDirectorySoftwarePublisherAgent) {
 		zap.L().Info("Skipping creation of Software publisher agent")


### PR DESCRIPTION
We want to support the OB Test Directory in both core and OB deployments.

For core, this means we can use OB certs when registering TPPs which is much simpler to configure than using certs issued by the Test Trusted Directory.

Removing OBRI directory software publisher as the OBRI deployment no longer exists.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1338