### PR TITLE
1529: Rename ApiClient.id field to softwareId

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/apiClient.json
+++ b/config/defaults/secure-open-banking/managed-objects/apiClient.json
@@ -31,6 +31,16 @@
             "isVirtual": false,
             "deleteQueryConfig": false
           },
+          "softwareId": {
+            "title": "software_id",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": true,
+            "description": null,
+            "isVirtual": false,
+            "deleteQueryConfig": false
+          },
           "name": {
             "title": "API Client Name",
             "type": "string",
@@ -157,7 +167,7 @@
         },
         "order": [
           "_id",
-          "id",
+          "softwareId",
           "name",
           "description",
           "deleted",
@@ -168,13 +178,17 @@
           "oauth2ClientId"
         ],
         "required": [
-          "id",
           "name",
           "oauth2ClientId",
           "ssa",
           "deleted"
         ],
         "mat-icon": null
+      },
+      "onRead": {
+        "type": "text/javascript",
+        "globals": {},
+        "source": "if (object.softwareId === undefined) {\n  object.softwareId = object.id\n}"
       },
       "iconClass": "fa fa-database",
       "type": "Managed Object"


### PR DESCRIPTION
The ApiClient.id field is confusing, it is not the unique id of an ApiClient object, the _id field should be used for this purpose.

The field actually represents the softwareId (which is not unique, multiple clients may be registered for the same piece of software).

In this change we are "renaming" the id field in a non breaking fashion by doing the following:
- Adding new field: `softwareId` which is optional
- Making the existing `id` field optional.
- Adding an onRead script which defaults the `softwareId` field to the `id` value 

Using the script prevents this from being a breaking change by providing a default value for the softwareId.

This change can be applied prior to deploying a code change that uses the softwareId field.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1529