### PR TITLE
1679: Migrate IG Components to Helm

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/job.yaml
@@ -75,7 +75,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: ob-deployment-config
-                  key: TRUSTEDDIR_FQDN
+                  key: TEST_DIRECTORY_FQDN
             - name: IDENTITY.GOOGLE_SECRET_STORE_PROJECT
               valueFrom:
                 configMapKeyRef:
@@ -204,7 +204,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: as-sapig-deployment-config
-                  key: TRUSTEDDIR_FQDN
+                  key: TEST_DIRECTORY_FQDN
             - name: IDENTITY.GOOGLE_SECRET_STORE_PROJECT
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Update TRUSTEDDIR_FQDN > TEST_DIRECTORY_FQDN as part of standardization during the kustoimize > helm epic

Issue:  https://github.com/SecureApiGateway/SecureApiGateway/issues/1679