### PR TITLE
1700: Can we create a FAPI Realm

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/job.yaml
@@ -74,6 +74,11 @@ spec:
                 configMapKeyRef:
                   name: as-sapig-deployment-config
                   key: TEST_DIRECTORY_FQDN
+            - name: IDENTITY.AM_REALM
+              valueFrom:
+                configMapKeyRef:
+                  name: as-sapig-deployment-config
+                  key: AM_REALM
             {{- if eq .Values.job.environment.cloudType "FIDC" }}
             - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
               valueFrom:

--- a/config/defaults/secure-open-banking/cors-login-ui.json
+++ b/config/defaults/secure-open-banking/cors-login-ui.json
@@ -2,7 +2,7 @@
   "_id": "login-ui-cors",
   "enabled": true,
   "acceptedOrigins": [
-    "https://{{.Hosts.ASFQDN}}, https://{{.Hosts.RSFQDN}}"
+    "https://{{.Hosts.ASFQDN}}","https://{{.Hosts.RSFQDN}}"
   ],
   "acceptedMethods": [
     "POST",


### PR DESCRIPTION
Set the environment variable IDENTITY_AMREALM which is usually set to alpha by default, based off the value in AM_REALM in the fapi-pep-as configmap

This will allow us to overwrite the default alpha and create the realm fapi in our test, this can be merged and stay in place as we've previously discussed using bravo realm for core|ob split like we do in AIC 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1700