### PR TITLE
OPENIG-10326 Update JWKS URI in oauth2.go to point to the correct API directory.

### DIFF
--- a/pkg/securebanking/oauth2.go
+++ b/pkg/securebanking/oauth2.go
@@ -203,7 +203,7 @@ func CreateSoftwarePublisherAgentTestPublisher() {
 		},
 		JwksURI: types.InheritedValueString{
 			Inherited: false,
-			Value:     "https://" + common.Config.Hosts.TrustedDirFQDN + "/jwkms/testdirectory/jwks",
+			Value:     "https://" + common.Config.Hosts.TrustedDirFQDN + "/api/directory/jwks",
 		},
 	}
 	path := "/am/json/realms/root/realms/" + common.Config.Identity.AmRealm + "/realm-config/agents/SoftwarePublisher/" + common.Config.Identity.SecureApiGatewayDevTrustedDirectory


### PR DESCRIPTION
Which the API changes on the sample trusted directory, the AM configuration needs to be aligned.