### PR TITLE
Update rsDeploymentConfigMap default to ig-fapi-pep-rs-config

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -24,7 +24,7 @@ job:
     # STRICT mode will simply warn of client/server errors.
     strict: true
     asDeploymentConfigMap: ig-fapi-pep-as-config
-    rsDeploymentConfigMap: rs-sapig-deployment-config
+    rsDeploymentConfigMap: ig-fapi-pep-rs-config
     asSecret: ig-fapi-pep-as-secrets
   image:
     # Repo And Tag are not provided here as the value for the repo will be unique for each user/customer as they will be building their own docker images and push to their own Container Registries 


### PR DESCRIPTION
The RS deployment config is now produced by the ig-fapi-pep-rs Helm chart (migrated into openig), which names its ConfigMap ig-fapi-pep-rs-config.