### PR TITLE
OPENIG-10514 Restore IG Policy Agent support for OB sapig type

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/job.yaml
@@ -148,6 +148,16 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.job.environment.rsDeploymentConfigMap }}
                   key: RCS_CONSENT_RESPONSE_JWT_ISSUER
+            - name: IG.IG_AGENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.job.environment.rsObSecret }}
+                  key: IG_AGENT_ID
+            - name: IG.IG_AGENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.job.environment.rsObSecret }}
+                  key: IG_AGENT_PASSWORD
             {{ end }}
             - name: IG.IG_CLIENT_ID
               valueFrom:

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -26,6 +26,7 @@ job:
     asDeploymentConfigMap: ig-fapi-pep-as-config
     rsDeploymentConfigMap: ig-fapi-pep-rs-config
     asSecret: ig-fapi-pep-as-secrets
+    rsObSecret: fapi-pep-rs-ob-secrets
   image:
     # Repo And Tag are not provided here as the value for the repo will be unique for each user/customer as they will be building their own docker images and push to their own Container Registries 
     # The tag will use the .AppVersion as the default, meaning that customers who want to install V1 will get V1.0.0 of the software - you may supply a hard coded version if required  

--- a/main.go
+++ b/main.go
@@ -125,6 +125,10 @@ func main() {
 	platform.CreateIGServiceUser()
 	platform.CreateIGOAuth2Client()
 
+	if common.Config.Environment.SapigType == "ob" {
+		platform.CreateIGPolicyAgent()
+	}
+
 	platform.ApplySystemClients(session.Cookie)
 
 	time.Sleep(5 * time.Second)

--- a/pkg/identity-platform/platform.go
+++ b/pkg/identity-platform/platform.go
@@ -72,6 +72,27 @@ func CreateIGOAuth2Client() {
 	zap.S().Infow("IG OAuth2 Client", "statusCode", s)
 }
 
+// CreateIGPolicyAgent -
+func CreateIGPolicyAgent() {
+	zap.L().Info("Creating IG Policy agent")
+	policyAgent := &types.PolicyAgent{
+		Userpassword: common.Config.Ig.IgAgentPassword,
+		IgTokenIntrospection: types.IgTokenIntrospection{
+			Value:     "Realm",
+			Inherited: false,
+		},
+	}
+	path := fmt.Sprintf("/am/json/realms/root/realms/"+common.Config.Identity.AmRealm+"/realm-config/agents/IdentityGatewayAgent/%s", common.Config.Ig.IgAgentId)
+	s := httprest.Client.Put(path, policyAgent, map[string]string{
+		"Accept":           "application/json",
+		"Content-Type":     "application/json",
+		"Connection":       "keep-alive",
+		"X-Requested-With": "ForgeRock Identity Cloud Postman Collection",
+	})
+
+	zap.S().Infow("IG Policy Agent", "statusCode", s)
+}
+
 func CreateIdentityPlatformOAuth2AdminClient(cookie *http.Cookie) {
 	zap.L().Info("Creating Identity Platform admin oauth2 client")
 

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -53,6 +53,8 @@ type ig struct {
 	IgSsaSecret     string `mapstructure:"IG_SSA_SECRET"`
 	IgIdmUser       string `mapstructure:"IG_IDM_USER"`
 	IgIdmPassword   string `mapstructure:"IG_IDM_PASSWORD"`
+	IgAgentId       string `mapstructure:"IG_AGENT_ID"`
+	IgAgentPassword string `mapstructure:"IG_AGENT_PASSWORD"`
 }
 type environment struct {
 	Verbose    bool   `mapstructure:"VERBOSE"`


### PR DESCRIPTION
Restores the IG Agent ID and password configuration that was accidentally removed in commit 9dd7cdf. The IG Policy Agent creation is now conditional on sapigType=ob, and references a new rsObSecret value instead of the previously hardcoded secret name.